### PR TITLE
Removing prod/dev config

### DIFF
--- a/application.py
+++ b/application.py
@@ -7,7 +7,6 @@ Created on 5/27/2015
 
 This starts flask dashboard.
 All the configs are in beach.config.py
-Bind to PORT if defined, otherwise default to 8080
 '''
 
 from beach import application

--- a/beach/__init__.py
+++ b/beach/__init__.py
@@ -12,19 +12,12 @@ loads config into dashboard object depends on web server
 from flask import Flask
 import os
 
-from beach.config import DevConfig
-from beach.config import ProdConfig
+from beach.config import Config
 
 
 application = Flask(__name__)
 application.secret_key = 'A0Zr98j/3yX R~XHH!jmN]LWX/,?RT'
-
-
-if os.uname()[1] in ['R-n-D-MacBook-Pro.local', 'R-n-D-MacBook-Pro-3.local']:
-    application.config.from_object(DevConfig)
-else:
-    application.config.from_object(ProdConfig)
-
+application.config.from_object(Config)
 
 from beach.views.contribution import cont
 from beach.views.impact import imp

--- a/beach/config.py
+++ b/beach/config.py
@@ -11,6 +11,8 @@ import os
 class Config(object):
     #Flask config
     TESTING = False
+    PORT = 80
+    DEBUG = True
 
     #DB config
     DB_SERVER = os.environ['DB_SERVER']
@@ -18,14 +20,3 @@ class Config(object):
     DB_PASSWORD = os.environ['DB_PASSWORD']
     DB_DATABASE = os.environ['DB_DATABASE']
     DB_PORT = int(os.environ['DB_PORT'])
-
-
-
-class ProdConfig(Config):
-    PORT = 80
-    DEBUG = True
-
-
-class DevConfig(Config):
-    PORT = 8080
-    DEBUG = True


### PR DESCRIPTION
The config selection was based on the name of the laptop which doesn't make a lot of sense. The only real difference between Prod and Dev was the port numbers which now defaults to 80. 