### PR TITLE
making site_name concat of all fields in site table

### DIFF
--- a/beach/views/contribution.py
+++ b/beach/views/contribution.py
@@ -154,7 +154,7 @@ def get_sites():
     Get all the possible possible inputs for pull down
     """
     query = """
-    SELECT site_id, CONCAT(county, ', ', town, ', ', COALESCE(street, '')) AS site_name
+    SELECT site_id, CONCAT(COALESCE(site_name, ''), ', ', COALESCE(street, ''), ', ', COALESCE(town, ''), ', ', COALESCE(county, ''), ', ', COALESCE(state, ','), ', ', COALESCE(zipcode, '')) AS site_name
     FROM coa.site ORDER BY county, town, street;
     """
     sites = db.fetch_data(query)


### PR DESCRIPTION
The legacy app that populates the data input screen site name dropdown uses street, county, and town to make unique site names. Additional data has made the site names not unique/not descriptive enough and gives the appearance of missing data. Altering query to use all fields in site table so site names are unique and descriptive. 